### PR TITLE
Add links for py_trees and py_trees_ros

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,11 @@
 # py_trees Parser
 
-This is a xml parser for processing and building a py_trees behavior tree. The
-hope is that most if not all capabilities of py_trees will be available for xml
-parsing. As such, a py_trees behavior tree can be created by simply creating an
-xml file.
+This is a xml parser for processing and building a
+[py_trees](https://github.com/splintered-reality/py_trees) behavior tree. The
+hope is that most if not all capabilities of py_trees and
+[py_trees_ros](https://github.com/splintered-reality/py_trees_ros) will be
+available for xml parsing. As such, a py_trees behavior tree can be created by
+simply creating an xml file.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # py_trees Parser
 
-This is a xml parser for processing and building a
+This is an xml parser for processing and building a
 [py_trees](https://github.com/splintered-reality/py_trees) behavior tree. The
 hope is that most if not all capabilities of py_trees and
 [py_trees_ros](https://github.com/splintered-reality/py_trees_ros) will be


### PR DESCRIPTION
This MR adds links for py_trees and py_trees_ros to the README

## Motivation and Context

To gain a bit more visibility with search engines it is good to have external links to related projects.

## Changes

- Add py_trees and py_trees_ros links to README

## Type of changes

- New feature

[comment]: # (Delete the lines in "Type of changes" that are not appropriate)

## Checklist

- [x] Update dependencies
- [x] Update version
- [x] Update README

## Testing

No testing needed as no code was changed.
