### PR TITLE
Feature: Add argument substitution within strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,14 @@ and then inside the subtree
 </py_trees.composites.Sequence>
 ```
 
+Additionally, arguments can be embedded within strings for partial substitution using the same syntax:
+
+```xml
+<py_trees.composites.Sequence name="Embedded Arg Tutorial">
+    <py_trees.behaviors.Success name="prefix_${foo}_suffix" />
+</py_trees.composites.Sequence>
+```
+
 Furthermore, one can cascade arguments down subtrees using the following syntax:
 
 ```xml
@@ -204,7 +212,7 @@ and in subtree1
 <subtree
   name="my_subtree2"
   include="/location/of/subtree2.xml" >
-  <arg name="baz" value=${foo}
+  <arg name="baz" value="${foo}" />
 </subtree>
 ```
 

--- a/py_trees_parser/parser.py
+++ b/py_trees_parser/parser.py
@@ -404,6 +404,29 @@ class BTParser:
                 self.logger.error(f"Argument '{var_name}' not found in arg list: {args}")
                 raise ValueError(f"Argument '{var_name}' not found in arg list")
 
+        # Support for argument substitution within strings
+        elif isinstance(var, str) and "${" in var and "}" in var:
+            result = var
+            # Find all ${...} patterns in the string
+            start_idx = 0
+            while "${" in result[start_idx:]:
+                start = result.find("${", start_idx)
+                end = result.find("}", start + 2)
+                if end == -1:
+                    break
+                
+                arg_name = result[start+2:end]
+                if arg_name in args:
+                    # Replace the argument with its value
+                    result = result[:start] + args[arg_name] + result[end+1:]
+                    # Start searching from the position after the replacement
+                    start_idx = start + len(args[arg_name])
+                else:
+                    self.logger.error(f"Argument '{arg_name}' not found in arg list: {args}")
+                    raise ValueError(f"Argument '{arg_name}' not found in arg list")
+                    
+            return result
+
         return None
 
     def _build_tree(

--- a/py_trees_parser/parser.py
+++ b/py_trees_parser/parser.py
@@ -406,17 +406,17 @@ class BTParser:
                 end = result.find("}", start + 2)
                 if end == -1:
                     break
-                
-                arg_name = result[start+2:end]
+
+                arg_name = result[start + 2 : end]
                 if arg_name in args:
                     # Replace the argument with its value
-                    result = result[:start] + args[arg_name] + result[end+1:]
+                    result = result[:start] + args[arg_name] + result[end + 1 :]
                     # Start searching from the position after the replacement
                     start_idx = start + len(args[arg_name])
                 else:
                     self.logger.error(f"Argument '{arg_name}' not found in arg list: {args}")
                     raise ValueError(f"Argument '{arg_name}' not found in arg list")
-                    
+
             return result
 
         return None

--- a/py_trees_parser/parser.py
+++ b/py_trees_parser/parser.py
@@ -396,36 +396,38 @@ class BTParser:
                 xml_node.set(attr_name, arg_value)
 
     def _sub_args(self, args, var):
-        if is_arg(var):
-            var_name = var[2:-1]
-            if var_name in args:
-                return args[var_name]
-            else:
-                self.logger.error(f"Argument '{var_name}' not found in arg list: {args}")
-                raise ValueError(f"Argument '{var_name}' not found in arg list")
-
-        # Support for argument substitution within strings
-        elif isinstance(var, str) and "${" in var and "}" in var:
-            result = var
-            # Find all ${...} patterns in the string
-            start_idx = 0
-            while "${" in result[start_idx:]:
-                start = result.find("${", start_idx)
-                end = result.find("}", start + 2)
-                if end == -1:
-                    break
-                
-                arg_name = result[start+2:end]
-                if arg_name in args:
-                    # Replace the argument with its value
-                    result = result[:start] + args[arg_name] + result[end+1:]
-                    # Start searching from the position after the replacement
-                    start_idx = start + len(args[arg_name])
+        if isinstance(var, str) and "${" in var and "}" in var:
+            # Handle both full replacement and embedded arguments
+            if var.startswith("${") and var.endswith("}") and var.count("${") == 1:
+                # Case 1: Entire string is an argument (${arg})
+                var_name = var[2:-1]
+                if var_name in args:
+                    return args[var_name]
                 else:
-                    self.logger.error(f"Argument '{arg_name}' not found in arg list: {args}")
-                    raise ValueError(f"Argument '{arg_name}' not found in arg list")
+                    self.logger.error(f"Argument '{var_name}' not found in arg list: {args}")
+                    raise ValueError(f"Argument '{var_name}' not found in arg list")
+            else:
+                # Case 2: Arguments embedded within a string (prefix_${arg}_suffix)
+                result = var
+                # Find all ${...} patterns in the string
+                start_idx = 0
+                while "${" in result[start_idx:]:
+                    start = result.find("${", start_idx)
+                    end = result.find("}", start + 2)
+                    if end == -1:
+                        break
                     
-            return result
+                    arg_name = result[start+2:end]
+                    if arg_name in args:
+                        # Replace the argument with its value
+                        result = result[:start] + args[arg_name] + result[end+1:]
+                        # Start searching from the position after the replacement
+                        start_idx = start + len(args[arg_name])
+                    else:
+                        self.logger.error(f"Argument '{arg_name}' not found in arg list: {args}")
+                        raise ValueError(f"Argument '{arg_name}' not found in arg list")
+                        
+                return result
 
         return None
 

--- a/py_trees_parser/parser.py
+++ b/py_trees_parser/parser.py
@@ -397,37 +397,27 @@ class BTParser:
 
     def _sub_args(self, args, var):
         if isinstance(var, str) and "${" in var and "}" in var:
-            # Handle both full replacement and embedded arguments
-            if var.startswith("${") and var.endswith("}") and var.count("${") == 1:
-                # Case 1: Entire string is an argument (${arg})
-                var_name = var[2:-1]
-                if var_name in args:
-                    return args[var_name]
+            # Handle both full replacement and embedded arguments with the same logic
+            result = var
+            # Find all ${...} patterns in the string
+            start_idx = 0
+            while "${" in result[start_idx:]:
+                start = result.find("${", start_idx)
+                end = result.find("}", start + 2)
+                if end == -1:
+                    break
+                
+                arg_name = result[start+2:end]
+                if arg_name in args:
+                    # Replace the argument with its value
+                    result = result[:start] + args[arg_name] + result[end+1:]
+                    # Start searching from the position after the replacement
+                    start_idx = start + len(args[arg_name])
                 else:
-                    self.logger.error(f"Argument '{var_name}' not found in arg list: {args}")
-                    raise ValueError(f"Argument '{var_name}' not found in arg list")
-            else:
-                # Case 2: Arguments embedded within a string (prefix_${arg}_suffix)
-                result = var
-                # Find all ${...} patterns in the string
-                start_idx = 0
-                while "${" in result[start_idx:]:
-                    start = result.find("${", start_idx)
-                    end = result.find("}", start + 2)
-                    if end == -1:
-                        break
+                    self.logger.error(f"Argument '{arg_name}' not found in arg list: {args}")
+                    raise ValueError(f"Argument '{arg_name}' not found in arg list")
                     
-                    arg_name = result[start+2:end]
-                    if arg_name in args:
-                        # Replace the argument with its value
-                        result = result[:start] + args[arg_name] + result[end+1:]
-                        # Start searching from the position after the replacement
-                        start_idx = start + len(args[arg_name])
-                    else:
-                        self.logger.error(f"Argument '{arg_name}' not found in arg list: {args}")
-                        raise ValueError(f"Argument '{arg_name}' not found in arg list")
-                        
-                return result
+            return result
 
         return None
 

--- a/test/data/test_arg_substitution.xml
+++ b/test/data/test_arg_substitution.xml
@@ -2,4 +2,5 @@
   <py_trees.behaviours.Running name="prefix_${arg1}_suffix" />
   <py_trees.behaviours.Success name="task_${arg2}_complete" />
   <py_trees.behaviours.Periodic name="periodic_${arg3}" n="${n}" />
+  <py_trees.behaviours.Success name="multiple_${arg1}_and_${arg2}_args" />
 </py_trees.composites.Selector> 

--- a/test/data/test_arg_substitution.xml
+++ b/test/data/test_arg_substitution.xml
@@ -1,0 +1,5 @@
+<py_trees.composites.Selector name="Argument Substitution Test" memory="$(False)">
+  <py_trees.behaviours.Running name="prefix_${arg1}_suffix" />
+  <py_trees.behaviours.Success name="task_${arg2}_complete" />
+  <py_trees.behaviours.Periodic name="periodic_${arg3}" n="${n}" />
+</py_trees.composites.Selector> 

--- a/test/data/test_arg_substitution_main.xml
+++ b/test/data/test_arg_substitution_main.xml
@@ -1,0 +1,6 @@
+<subtree name="test_arg_substitution" include="$(ament_index_python.get_package_share_directory('py_trees_parser') + '/test/data/test_arg_substitution.xml')" >
+  <arg name="arg1" value="value1" />
+  <arg name="arg2" value="value2" />
+  <arg name="arg3" value="value3" />
+  <arg name="n" value="3" />
+</subtree> 

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -121,7 +121,10 @@ def test_arg_substitution_within_strings(setup_parser):
         if isinstance(child, py_trees.behaviours.Running):
             assert child.name == "prefix_value1_suffix"
         elif isinstance(child, py_trees.behaviours.Success):
-            assert child.name == "task_value2_complete"
+            if "multiple" in child.name:
+                assert child.name == "multiple_value1_and_value2_args"
+            elif "task" in child.name:
+                assert child.name == "task_value2_complete"
         elif isinstance(child, py_trees.behaviours.Periodic):
             assert child.name == "periodic_value3"
             assert child.period == 3

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -68,6 +68,7 @@ def setup_parser(ros_init):
         "test/data/test_idioms.xml",
         "test/data/test_function_parse.xml",
         "test/data/test_subtree_main.xml",
+        "test/data/test_arg_substitution_main.xml",
     ],
 )
 def test_tree_parser(setup_parser, tree_file):
@@ -105,5 +106,24 @@ def test_subtree_cascaded_args(setup_parser):
         elif isinstance(child, py_trees.behaviours.Periodic):
             assert child.name == "Flip Eggs"
             assert child.period == 2
+        else:
+            assert False, f"Unexpected child node type {type(child)}"  # noqa
+
+
+def test_arg_substitution_within_strings(setup_parser):
+    """Test that argument substitution within strings works as expected."""
+    tree_file = "test/data/test_arg_substitution_main.xml"
+    root = setup_parser(tree_file)
+
+    assert root.name == "Argument Substitution Test"
+
+    for child in root.children:
+        if isinstance(child, py_trees.behaviours.Running):
+            assert child.name == "prefix_value1_suffix"
+        elif isinstance(child, py_trees.behaviours.Success):
+            assert child.name == "task_value2_complete"
+        elif isinstance(child, py_trees.behaviours.Periodic):
+            assert child.name == "periodic_value3"
+            assert child.period == 3
         else:
             assert False, f"Unexpected child node type {type(child)}"  # noqa


### PR DESCRIPTION
Add argument substitution within strings #4 

This PR implements argument substitution within strings (issue #4). Previously, arguments were only used as entire attribute values like `name="${my_arg}"`, but now they can be embedded within strings like `name="variable_${my_arg}"`.

- Enhanced the `_sub_args` method to detect and replace argument patterns within larger strings
- Added comprehensive tests for the new functionality
- Updated documentation in README.md with examples

Example usage
```xml
<py_trees.behaviours.Success name="prefix_${arg1}_suffix" />
```

This allows for more flexible behaviour tree configurations where arguments need to be part of a larger string.

Please let me know if anything needed to be fixed.