### PR TITLE
Use diff in ruff linting

### DIFF
--- a/.ci/python/lint.sh
+++ b/.ci/python/lint.sh
@@ -22,5 +22,4 @@ pip install ruff==0.9.2
 ruff check .
 
 # check if formatting is correct (~ equivalent of `black format --check`)
-ruff format --check .
-
+ruff format --diff .

--- a/.ci/python/lint.sh
+++ b/.ci/python/lint.sh
@@ -19,7 +19,7 @@ export PATH=$PATH:$HOME/.local/bin
 pip install ruff==0.9.2
 
 # lint the code (replaces flake8, isort, etc.)
-ruff check .
+ruff check --diff .
 
 # check if formatting is correct (~ equivalent of `black format --check`)
 ruff format --diff .


### PR DESCRIPTION
This MR changes the CI to display a diff when ruff says a change is needed.

## Motivation and Context

Currently the ruff linting only tells you a file needs a change, but not what the change is. This change will create diffs when the linting fails, so that it is much clearer what needs to be fixed.

## Changes

- Switch to diff in ruff command

## Type of changes

- New feature
