### PR TITLE
Add ability to use python logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,14 +95,10 @@ following code:
 ```python
 from py_trees_parser import BTParser
 import py_trees
-from rclpy import logging
-
-logger = logging.get_logger('parser')
-logger.set_level(logging.LoggingSeverity.DEBUG)
 
 # Parse the XML file and create the behavior tree:
 xml_file = "behavior_tree.xml"
-parser = BTParser(xml_file, logger)
+parser = BTParser(xml_file)
 behavior_tree = parser.parse()
 ```
 
@@ -219,3 +215,37 @@ and finally in subtree2
     <py_trees.behaviors.Success name="${baz}" />
 </py_trees.composites.Sequence>
 ```
+
+### Logging
+
+By default the parser uses `rclpy.logging` module to log messages. However, if this is not available
+it falls back to the python `logging` module. The user need not intervene to change the logger as the
+parser will determine which logger to use on its own.
+
+#### Logging Level
+
+If you would like to set the logging level you will need to know which logger is available. If you are
+using ROS2 then the logger will be `rclpy.logging` and the log level can be set in the following way
+
+```python
+import rclpy
+
+from py_trees_parser import BTParser
+
+xml_file = "behavior_tree.xml"
+parser = BTParser(xml_file, log_level=rclpy.logging.LoggingSeverity.DEBUG)
+```
+
+On the other hand if you are not using ROS2 then the log level can be set in the following way
+
+```python
+import logging
+
+from py_trees_parser import BTParser
+
+xml_file = "behavior_tree.xml"
+parser = BTParser(xml_file, log_level=logging.DEBUG)
+```
+
+- For details on ROS2 log levels see [here](https://docs.ros2.org/foxy/api/rclpy/api/logging.html).
+- For details on python log levels see [here](https://docs.python.org/3/library/logging.html#logging-levels)

--- a/py_trees_parser/parser.py
+++ b/py_trees_parser/parser.py
@@ -29,8 +29,12 @@ from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
 import py_trees
-import rclpy
-from rclpy import logging
+
+try:
+    import rclpy
+    from rclpy import logging
+except ModuleNotFoundError:
+    import logging
 
 
 class BTParseError(Exception):
@@ -169,20 +173,30 @@ class BTParser:
     Args:
     ----
         file (str): The XML file to parse.
-        log_level (logging.LoggingSeverity, optional): The logging level for the parser.
+        log_level (optional): The logging level for the parser. This can be
+                              rclpy.logging.LoggingSeverity or the log levels from logging.
+                              Default logging level is INFO.
 
     """
 
     def __init__(
         self,
         file: str,
-        log_level: logging.LoggingSeverity = logging.LoggingSeverity.INFO,
+        log_level: rclpy.logging.LoggingSeverity | int | None = None,
     ):
         """Initialize the BTParser."""
         self.file = file
 
-        self.logger = rclpy.logging.get_logger("BTParser")
-        self.logger.set_level(log_level)
+        try:
+            self.logger = logging.get_logger("BTParser")
+            self.logger.set_level(
+                log_level if log_level is not None else logging.LoggingSeverity.INFO
+            )
+        except AttributeError:
+            formatter = logging.Formatter("[%(levelname)s] [%(name)s] [%(created)f]: %(message)s")
+            self.logger = logging.getLogger("BTParser")
+            self.logger.setLevel(log_level if log_level is not None else logging.INFO)
+            self.logger.setFormatter(formatter)
 
     def _get_handle(self, value: str) -> tuple[str, Any]:
         """


### PR DESCRIPTION
This PR adds the ability to use python logging instead of rclpy.logging and removes the only real ROS2 dependency.

Fixes #8 

## Motivation and Context

The only real ROS2 dependency of this parser was the `rclpy.logging` module, so to remove that dependency but still make it possible to use `rclpy.logging` I added a selector for logging module dependent on if the `rclpy.logging` module was imported.

## Changes

- Add logging selector

## Type of changes

- New feature

[comment]: # (Delete the lines in "Type of changes" that are not appropriate)

## Checklist

- [ ] Update dependencies
- [ ] Update version
- [x] Update README

## Testing

Run the parser on some example trees. If there are no exceptions thrown and the tree is built then it is working.
