### PR TITLE
Fix reading string booleans

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,10 +52,6 @@ and should be evaluated as code. For a concrete example see below:
 In the above example the `qos_profile` is evaluated as python code. Notice to
 use any python module you must use the fully qualified name.
 
-note: Boolean values should be considered python as checking the truth of a
-python string will always be evaluated as `True`, e.g. `if "False":` will evaluate
-to `True`.
-
 ### Idioms
 
 Idioms are also now supported. An idiom is a special function that produces
@@ -79,14 +75,14 @@ Create an XML file that represents your behavior tree. The XML structure should
 define the nodes and their attributes. It should be similar to the following:
 
 ```xml
-<py_trees.composites.Parallel name="TutorialOne" synchronise="$(False)">
-    <py_trees.composites.Sequence name="Topics2BB" memory="$(False)">
+<py_trees.composites.Parallel name="TutorialOne" synchronise="False">
+    <py_trees.composites.Sequence name="Topics2BB" memory="False">
         <py_trees_ros.battery.ToBlackboard name="Battery2BB"
             topic_name="/battery/state"
             qos_profile="$(py_trees_ros.utilities.qos_profile_unlatched())"
             threshold="30.0" />
     </py_trees.composites.Sequence>
-    <py_trees.composites.Selector name="Tasks" memory="$(False)">
+    <py_trees.composites.Selector name="Tasks" memory="False">
         <py_trees.behaviours.Running name="Idle" />
         <py_trees.behaviours.Periodic name="Flip Eggs" n="2" />
     </py_trees.composites.Selector>
@@ -162,7 +158,7 @@ another subtree. However, be aware that the all directories are absolute, but it
 is possible to use python to determine the path like so:
 
 ```xml
-<py_trees.composites.Parallel name="Subtree Tutorial" synchronise="$(False)">
+<py_trees.composites.Parallel name="Subtree Tutorial" synchronise="False">
     <subtree
       name="my_subtree"
       include="$(os.path.join(ament_index_python.packages.get_package_share_directory('my_package'), 'tree', 'subtree.xml'))" />

--- a/py_trees_parser/parser.py
+++ b/py_trees_parser/parser.py
@@ -59,6 +59,22 @@ def is_float(value: str) -> bool:
         return False
 
 
+def is_bool(value: str) -> bool:
+    """
+    Check if a string is a boolean type, i.e. True or False.
+
+    Args:
+    ----
+        value: The string to check.
+
+    Returns:
+    -------
+        True if the string is "true", "True", "false", or "False", False otherwise.
+
+    """
+    return value.lower() == "true" or value.lower() == "false"
+
+
 def is_code(value: str) -> bool:
     """
     Check if a string is intended to be code.
@@ -244,6 +260,8 @@ class BTParser:
             value = int(value)
         elif is_float(value):
             value = float(value)
+        elif is_bool(value):
+            value = value.lower() == "true"
         elif is_code(value):
             value = self._parse_code(value)
 

--- a/test/data/test1.xml
+++ b/test/data/test1.xml
@@ -2,13 +2,13 @@
     https://py-trees-ros-tutorials.readthedocs.io/en/release-2.1.x/tutorials.html#tree -->
 <py_trees.composites.Parallel name="TutorialOne"
   policy="$(py_trees.common.ParallelPolicy.SuccessOnAll(synchronise=False))">
-  <py_trees.composites.Sequence name="Topics2BB" memory="$(False)">
+  <py_trees.composites.Sequence name="Topics2BB" memory="False">
     <py_trees_ros.battery.ToBlackboard name="Battery2BB"
       topic_name="/battery/state"
       qos_profile="$(py_trees_ros.utilities.qos_profile_unlatched())"
       threshold="30.0" />
   </py_trees.composites.Sequence>
-  <py_trees.composites.Selector name="Tasks" memory="$(False)">
+  <py_trees.composites.Selector name="Tasks" memory="False">
     <py_trees.behaviours.Running name="Idle" />
     <py_trees.behaviours.Periodic name="Flip Eggs" n="2" />
   </py_trees.composites.Selector>

--- a/test/data/test6.xml
+++ b/test/data/test6.xml
@@ -2,7 +2,7 @@
     https://py-trees-ros-tutorials.readthedocs.io/en/release-2.1.x/tutorials.html#id13 -->
 <py_trees.composites.Parallel name="TutorialSix"
   policy="$(py_trees.common.ParallelPolicy.SuccessOnAll(synchronise=False))">
-  <py_trees.composites.Sequence name="Topics2BB" memory="$(False)">
+  <py_trees.composites.Sequence name="Topics2BB" memory="False">
     <py_trees_ros.subscribers.EventToBlackboard name="Scan2BB"
       topic_name="/dashboard/scan"
       qos_profile="$(py_trees_ros.utilities.qos_profile_unlatched())"
@@ -10,16 +10,16 @@
     <py_trees_ros.battery.ToBlackboard name="Battery2BB" topic_name="/battery/state"
       qos_profile="py_trees_ros.utilities.qos_profile_unlatched()" threshold="30.0" />
   </py_trees.composites.Sequence>
-  <py_trees.composites.Selector name="Tasks" memory="$(False)">
+  <py_trees.composites.Selector name="Tasks" memory="False">
     <py_trees.decorators.EternalGuard name="Battery Low?"
       condition="$(py_trees_parser.behaviors.testing_behaviors.check_battery_low_on_blackboard)"
       blackboard_keys="$({'battery_low_warning'})">
       <py_trees_parser.behaviors.testing_behaviors.FlashLedStrip name="Flash Red" colour="red" />
     </py_trees.decorators.EternalGuard>
-    <py_trees.composites.Sequence name="Scan" memory="$(False)">
+    <py_trees.composites.Sequence name="Scan" memory="False">
       <py_trees.behaviours.CheckBlackboardVariableValue name="Scan?"
         check="$(py_trees.common.ComparisonExpression(variable='event_scan_button', value=True, operator=operator.eq))" />
-      <py_trees.composites.Selector name="Preempt?" memory="$(False)">
+      <py_trees.composites.Selector name="Preempt?" memory="False">
         <py_trees.decorators.SuccessIsRunning name="SuccessIsRunning">
           <py_trees.behaviours.CheckBlackboardVariableValue name="Scan?"
             check="$(py_trees.common.ComparisonExpression(variable='event_scan_button', value=True, operator=operator.eq))" />

--- a/test/data/test_arg_substitution.xml
+++ b/test/data/test_arg_substitution.xml
@@ -1,6 +1,6 @@
-<py_trees.composites.Selector name="Argument Substitution Test" memory="$(False)">
+<py_trees.composites.Selector name="Argument Substitution Test" memory="False">
   <py_trees.behaviours.Running name="prefix_${arg1}_suffix" />
   <py_trees.behaviours.Success name="task_${arg2}_complete" />
   <py_trees.behaviours.Periodic name="periodic_${arg3}" n="${n}" />
   <py_trees.behaviours.Success name="multiple_${arg1}_and_${arg2}_args" />
-</py_trees.composites.Selector> 
+</py_trees.composites.Selector>

--- a/test/data/test_arg_substitution_main.xml
+++ b/test/data/test_arg_substitution_main.xml
@@ -3,4 +3,4 @@
   <arg name="arg2" value="value2" />
   <arg name="arg3" value="value3" />
   <arg name="n" value="3" />
-</subtree> 
+</subtree>

--- a/test/data/test_bool.xml
+++ b/test/data/test_bool.xml
@@ -1,0 +1,5 @@
+<py_trees.composites.Sequence name="No Memory" memory="False">
+  <py_trees.composites.Sequence name="Memory" memory="True">
+    <py_trees.behaviours.Success name="Feature 1" />
+  </py_trees.composites.Sequence>
+</py_trees.composites.Sequence>

--- a/test/data/test_idioms.xml
+++ b/test/data/test_idioms.xml
@@ -1,4 +1,4 @@
-<py_trees.composites.Sequence name="Idioms" memory="$(False)">
+<py_trees.composites.Sequence name="Idioms" memory="False">
   <py_trees.idioms.oneshot name="OneShot"
     variable_name="one_shot"
     policy="$(py_trees.common.OneShotPolicy)">

--- a/test/data/test_subtree_args.xml
+++ b/test/data/test_subtree_args.xml
@@ -1,4 +1,4 @@
-<py_trees.composites.Selector name="${selector_name}" memory="$(False)">
+<py_trees.composites.Selector name="${selector_name}" memory="False">
   <py_trees.behaviours.Running name="${idle_name}" />
   <py_trees.behaviours.Periodic name="${flip_name}" n="${n}" />
 </py_trees.composites.Selector>

--- a/test/data/test_subtree_main.xml
+++ b/test/data/test_subtree_main.xml
@@ -1,6 +1,6 @@
 <py_trees.composites.Parallel name="SubtreeMain"
   policy="$(py_trees.common.ParallelPolicy.SuccessOnAll(synchronise=False))">
-  <py_trees.composites.Sequence name="Topics2BB" memory="$(False)">
+  <py_trees.composites.Sequence name="Topics2BB" memory="False">
     <py_trees_ros.battery.ToBlackboard name="Battery2BB" topic_name="/battery/state"
       qos_profile="$(py_trees_ros.utilities.qos_profile_unlatched())" threshold="30.0" />
   </py_trees.composites.Sequence>

--- a/test/data/test_subtree_sub.xml
+++ b/test/data/test_subtree_sub.xml
@@ -1,4 +1,4 @@
-<py_trees.composites.Selector name="SubTreeSub" memory="$(False)">
+<py_trees.composites.Selector name="SubTreeSub" memory="False">
   <py_trees.behaviours.Running name="Idle" />
   <py_trees.behaviours.Periodic name="Flip Eggs" n="2" />
 </py_trees.composites.Selector>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -130,3 +130,14 @@ def test_arg_substitution_within_strings(setup_parser):
             assert child.period == 3
         else:
             assert False, f"Unexpected child node type {type(child)}"  # noqa
+
+
+def test_bool(setup_parser):
+    """Test that True, true, False, or false are evaluated as booleans."""
+    tree_file = "test/data/test_bool.xml"
+    root = setup_parser(tree_file)
+
+    assert root.name == "No Memory"
+    assert root.memory is False
+    assert root.children[0].name == "Memory"
+    assert root.children[0].memory


### PR DESCRIPTION
This PR makes it so that "true", "True", "false", or "False" are evaluated as boolean values.

Fixes #6 

## Motivation and Context

When "False" is used as a parameter value it will evaluate to `True`, which is definitely not expected by most people. The workaround for this was to use `"$(False)"`, but that feels clumsy.

## Changes

- Fix reading strings as booleans

## Type of changes

- Bug fix

[comment]: # (Delete the lines in "Type of changes" that are not appropriate)

## Checklist

- [ ] Update dependencies
- [ ] Update version
- [x] Update README

## Testing

1. `colcon build --packages-up-to py_trees_parser`
2. `colcon test --event-handlers console_cohesion+ --packages-select py_trees_parser`
