### PR TITLE
Success on selected

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog for package py_trees_parser
 
 .. This is only a rough description of the main changes of the repository
+0.7.0 (2025-03-28)
+------------------
+* Add support for SuccessOnSelected parallel policy
+
 0.6.1 (2025-03-21)
 ------------------
 * Add inline argument substitution

--- a/README.md
+++ b/README.md
@@ -67,6 +67,14 @@ Additionally, it is possible to create a [subtree](#sub-trees), where a subtree 
 containing a complete behavior tree. This xml file can be included in other xml
 files and therefore allows for complete modularity of trees.
 
+### Parallel Policies
+
+When running a `py_trees.composites.Parallel` you can set a policy. For the
+`SuccessOnAll` and `SuccessOnOne` everything is straight forward, but for
+`SuccessOnSelected` one specifies the `children` as a list of `names`. Those
+names must be the names as provided in children that follow, as this is how
+the parser will build the parallel policy. See the example in [basic usage](#basic-usage).
+
 ### Basic Usage
 
 To use the Behavior Tree Parser, follow these steps:
@@ -75,7 +83,9 @@ Create an XML file that represents your behavior tree. The XML structure should
 define the nodes and their attributes. It should be similar to the following:
 
 ```xml
-<py_trees.composites.Parallel name="TutorialOne" synchronise="False">
+<py_trees.composites.Parallel
+  name="TutorialOne"
+  policy="$(py_trees.ParallelPolicy.SuccessOnSelected(children=[Tasks], synchronise=False))">
     <py_trees.composites.Sequence name="Topics2BB" memory="False">
         <py_trees_ros.battery.ToBlackboard name="Battery2BB"
             topic_name="/battery/state"

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>py_trees_parser</name>
-  <version>0.6.1</version>
+  <version>0.7.0</version>
   <description>A py_trees xml parser</description>
   <maintainer email="e.l.f.foster@tudelft.nl">Erich L Foster</maintainer>
   <license>Apache-2.0</license>

--- a/py_trees_parser/parser.py
+++ b/py_trees_parser/parser.py
@@ -116,6 +116,92 @@ def is_arg(value: str) -> bool:
     return value.startswith("${") and value.endswith("}")
 
 
+def extract_params(func: str) -> ast.Call | None:
+    """
+    Extract a list of parameters from a string representing a python function.
+
+    Args:
+    ----
+       func (str): string representing python function.
+
+    Returns:
+    -------
+       list(str): list of parameters found.
+
+    Raises:
+    ------
+       ValueError: if the function call is malformed.
+
+    """
+    try:
+        # Parse the string into an AST
+        tree = ast.parse(func)
+    except SyntaxError as ex:
+        raise ValueError(f"Couldn't read function parameters: {func}") from ex
+
+    # Find the first function call node in the AST
+    call_node = None
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Call):
+            call_node = node
+            break
+
+    return call_node
+
+
+def handle_success_on_selected(node_attribs: dict) -> tuple[list[str] | None, bool]:
+    """
+    Handle the special SuccessOnSelected parameter.
+
+    Args:
+    ----
+        node_attribs (dict): The attributes of the XML node.
+
+    Returns:
+    -------
+        A tuple containing the list of children to be selected and the synchonise parameter.
+
+    """
+    on_selected = None
+    synchronise = None
+    if (policy := node_attribs.get("policy")) is not None and "SuccessOnSelected" in policy:
+        call_node = extract_params(policy[2:-1])
+        if call_node is None:
+            raise ValueError(f"Missing parameters for 'SuccessOnSelected': {policy[2:-1]}")
+
+        positional_args = [ast.unparse(arg) for arg in call_node.args]
+        keyword_args = {key.arg: ast.unparse(key.value) for key in call_node.keywords}
+
+        children_arg = None
+        synchronise = None
+        if len(positional_args) == 2:
+            children_arg = positional_args[0]
+            synchronise = positional_args[1].lower() == "true"
+        elif len(positional_args) == 1:
+            children_arg = positional_args[0]
+
+        for key, value in keyword_args.items():
+            if key == "children":
+                children_arg = value
+            elif key == "synchronise":
+                synchronise = value.lower() == "true"
+
+        if children_arg is None:
+            raise ValueError(f"No children found in SuccessOnSelected: {policy[2:-1]}")
+
+        synchronise = True if synchronise is None else synchronise
+
+        start = children_arg.find("[")
+        end = children_arg.find("]", start + 1)
+        if end == -1:
+            raise ValueError(f"Malformed list of children in SuccessOnSelected: {policy[2:-1]}")
+        on_selected = [x.strip() for x in children_arg[start + 1 : end].split(",")]
+
+        del node_attribs["policy"]
+
+    return on_selected, synchronise
+
+
 def extract_modules(ast_tree: ast.AST) -> list[str]:
     """
     Extract module and submodules from the input AST.
@@ -384,6 +470,9 @@ class BTParser:
 
         self.logger.debug(f"Found {node_type}")
 
+        # handle SuccessOnSelected separately
+        on_selected, synchronise = handle_success_on_selected(node_attribs)
+
         # name is a special attribute that is handled separately
         node_attribs = self._convert_attribs(node_attribs)
 
@@ -391,22 +480,38 @@ class BTParser:
         if isinstance(obj, types.FunctionType):
             parameters = inspect.signature(obj).parameters
             if "behaviour" in parameters:
+                self.logger.debug("Found behaviour in parameters")
                 node = obj(name=name, behaviour=children[0], **node_attribs)
             elif "subtrees" in parameters:
+                self.logger.debug("Found subtrees in parameters")
                 node = obj(name=name, subtrees=children, **node_attribs)
             elif "tasks" in parameters:
+                self.logger.debug("Found tasks in parameters")
                 node = obj(name=name, tasks=children, **node_attribs)
             elif len(children) == 0:
+                self.logger.debug("No children provided, assuming a behavior")
                 node = obj(name=name, **node_attribs)
             else:
                 self.logger.error(f"Unknown node type {node_type}")
                 raise BTParseError(f"Unknown node type {node_type}")
-
         elif len(children) == 0:
+            self.logger.debug("No children provided, assuming a behavior")
             node = obj(name=name, **node_attribs)
         elif issubclass(obj, py_trees.decorators.Decorator):
-            self.logger.debug(f"{node_attribs = }")
+            self.logger.debug(f"Found decorator: {node_attribs = }")
             node = obj(name=name, child=children[0], **node_attribs)
+        elif on_selected is not None:
+            self.logger.debug("Found SuccessOnSelected in parameters")
+
+            selection = [child for child in children if child.name in on_selected]
+
+            node = obj(
+                name=name,
+                children=children,
+                policy=py_trees.common.ParallelPolicy.SuccessOnSelected(
+                    children=selection, synchronise=synchronise
+                ),
+            )
         else:
             node = obj(name=name, children=children, **node_attribs)
 
@@ -525,6 +630,7 @@ class BTParser:
             if not self._condition(if_cond):
                 continue
             child = self._build_tree(child_xml, args)
+
             children.append(child)
 
         # build the actual node

--- a/py_trees_parser/parser.py
+++ b/py_trees_parser/parser.py
@@ -159,7 +159,7 @@ def handle_success_on_selected(node_attribs: dict) -> tuple[list[str] | None, bo
 
     Returns:
     -------
-        A tuple containing the list of children to be selected and the synchonise parameter.
+        A tuple containing the list of children to be selected and the synchronise parameter.
 
     """
     on_selected = None
@@ -172,8 +172,6 @@ def handle_success_on_selected(node_attribs: dict) -> tuple[list[str] | None, bo
         positional_args = [ast.unparse(arg) for arg in call_node.args]
         keyword_args = {key.arg: ast.unparse(key.value) for key in call_node.keywords}
 
-        children_arg = None
-        synchronise = None
         if len(positional_args) == 2:
             children_arg = positional_args[0]
             synchronise = positional_args[1].lower() == "true"
@@ -189,6 +187,7 @@ def handle_success_on_selected(node_attribs: dict) -> tuple[list[str] | None, bo
         if children_arg is None:
             raise ValueError(f"No children found in SuccessOnSelected: {policy[2:-1]}")
 
+        # synchronise wasn't set so set it to the default value
         synchronise = True if synchronise is None else synchronise
 
         start = children_arg.find("[")

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ package_name = "py_trees_parser"
 
 setup(
     name=package_name,
-    version="0.6.1",
+    version="0.7.0",
     packages=find_packages(exclude=["test"]),
     data_files=[
         ("share/ament_index/resource_index/packages", [os.path.join("resource", package_name)]),

--- a/test/data/test_parallel_policy.xml
+++ b/test/data/test_parallel_policy.xml
@@ -1,0 +1,19 @@
+<py_trees.composites.Sequence name="ParallelPolicy Test" memory="False">
+  <py_trees.composites.Parallel
+    name="SuccessOnAll"
+    policy="$(py_trees.common.ParallelPolicy.SuccessOnAll())" >
+    <py_trees.behaviours.Success name="Feature1" />
+  </py_trees.composites.Parallel>
+  <py_trees.composites.Parallel
+    name="SuccessOnOne"
+    policy="$(py_trees.common.ParallelPolicy.SuccessOnOne())" >
+    <py_trees.behaviours.Success name="Feature2" />
+    <py_trees.behaviours.Success name="Feature3" />
+  </py_trees.composites.Parallel>
+  <py_trees.composites.Parallel
+    name="SuccessOnSelected"
+    policy="$(py_trees.common.ParallelPolicy.SuccessOnSelected(['Feature5']))" >
+    <py_trees.behaviours.Success name="Feature4" />
+    <py_trees.behaviours.Success name="Feature5" />
+  </py_trees.composites.Parallel>
+</py_trees.composites.Sequence>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -20,6 +20,7 @@ instances are valid.
 """
 
 import os
+from xml.etree import ElementTree
 
 import py_trees
 import py_trees_ros
@@ -27,7 +28,7 @@ import pytest
 import rclpy
 from ament_index_python.packages import get_package_share_directory
 
-from py_trees_parser.parser import BTParser
+from py_trees_parser.parser import BTParser, handle_success_on_selected
 
 SHARE_DIR = get_package_share_directory("py_trees_parser")
 
@@ -168,3 +169,73 @@ def test_conditionals(setup_parser):
     assert grand_children[0].name == "Subtree Feature 1"
     assert grand_children[1].name == "Subtree Feature 2"
     assert grand_children[2].name == "Subtree Feature 3"
+
+
+@pytest.mark.parametrize(
+    "child_key, synch_key, children, synch",
+    [
+        (True, True, ["feature_1"], True),
+        (True, True, ["Feature_2"], False),
+        (True, True, ["Feature_1", "Feature_2"], True),
+        (True, True, ["feature_1"], True),
+        (True, True, ["Feature_2"], False),
+        (False, True, ["feature_1"], True),
+        (False, True, ["Feature_2"], False),
+        (False, True, ["Feature_1", "Feature_2"], True),
+        (False, True, ["feature_1"], True),
+        (False, True, ["Feature_2"], False),
+        (False, False, ["feature_1"], True),
+        (False, False, ["Feature_2"], False),
+        (False, False, ["Feature_1", "Feature_2"], True),
+        (False, False, ["feature_1"], True),
+        (False, False, ["Feature_2"], False),
+        (True, False, ["feature_1"], None),
+        (True, False, ["Feature_2"], None),
+        (True, False, ["Feature_1", "Feature_2"], None),
+        (True, False, ["feature_1"], None),
+        (True, False, ["Feature_2"], None),
+        (True, False, ["Feature_1", "Feature_2"], None),
+    ],
+)
+def test_SuccessOnSelected_parsing(child_key, synch_key, children, synch):
+    """Test that we can parse SuccessOnSelected parameters."""
+    child_str = f"{'children=' if child_key else ''}[{', '.join(children)}]"
+
+    # choose to include synchronise parameter or not
+    if synch is not None:
+        synch_str = f"{'synchronise=' if synch_key else ''}{str(synch)}"
+        parallel_policy = (
+            f"py_trees.common.ParallelPolicy.SuccessOnSelected({child_str}, {synch_str})"
+        )
+    else:
+        synch = True
+        parallel_policy = f"py_trees.common.ParallelPolicy.SuccessOnSelected({child_str})"
+
+    xml_str = f"<py_trees.composites.Parallel name='TestParallel' policy='$({parallel_policy})' />"
+    node = ElementTree.fromstring(xml_str)
+
+    on_selected, synchronise = handle_success_on_selected(node.attrib)
+
+    for selected in on_selected:
+        assert selected in children
+
+    assert synchronise is synch
+
+    assert "policy" not in node.attrib
+
+
+def test_ParallelPolicy(setup_parser):
+    """Test parallel policies are handled correctly."""
+    tree_file = "test_parallel_policy.xml"
+    root = setup_parser(tree_file)
+
+    assert root.name == "ParallelPolicy Test"
+    for child in root.children:
+        if child.name == "SuccessOnAll":
+            assert isinstance(child.policy, py_trees.common.ParallelPolicy.SuccessOnAll)
+        elif child.name == "SuccessOnOne":
+            assert isinstance(child.policy, py_trees.common.ParallelPolicy.SuccessOnOne)
+        elif child.name == "SuccessOnSelected":
+            assert isinstance(child.policy, py_trees.common.ParallelPolicy.SuccessOnSelected)
+        else:
+            assert False, "Received unexpected parallel policy"  # noqa


### PR DESCRIPTION
This PR adds support for `py_trees.common.ParallelPolicy.SuccessOnSelected`.

Fixes #9 

## Motivation and Context

`SuccessOnSelected` required a list of children to be useful, but there was no method for reference children as parameters. This implements the ability to have such a parameter, but only for `SuccessOnSelected`.

## Changes

- Add support for `SuccessOnSelected`

## Type of changes

- New feature

[comment]: # (Delete the lines in "Type of changes" that are not appropriate)

## Checklist

- [ ] Update dependencies
- [x] Update version
- [x] Update README

## Testing

1. `colcon build --packages-up-to py_trees_parser`
2. `colcon test --event-handlers console_cohesion+ --packages-select py_trees_parser`
