### PR TITLE
fix: Handle special characters in child names

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,10 @@
 Changelog for package py_trees_parser
 
 .. This is only a rough description of the main changes of the repository
+0.7.1 (2025-08-27)
+------------------
+* SuccessOnSlected handling of special characters
+
 0.7.0 (2025-03-28)
 ------------------
 * Add support for SuccessOnSelected parallel policy

--- a/README.md
+++ b/README.md
@@ -113,6 +113,9 @@ parser = BTParser(xml_file)
 behavior_tree = parser.parse()
 ```
 
+note: The names given to children above would use an underscore, i.e. `_` for
+      any special characters, e.g. " ", "$", "@", "!", etc.
+
 ### Using Your Own Behaviors
 
 The xml parser can use any behavior, whether it is part of `py_trees`, `py_trees_ros`,
@@ -147,7 +150,6 @@ then you would include the behaviors in `my_behavior.py` in the following way:
 
 The path to this can be shortened by including the class in `__init__.py`.
 
-
 ### Sub-Trees
 
 It is possible to include sub-trees in the xml file containing a behavior tree.
@@ -171,6 +173,7 @@ is possible to use python to determine the path like so:
       include="$(os.path.join(ament_index_python.packages.get_package_share_directory('my_package'), 'tree', 'subtree.xml'))" />
 </py_trees.composites.Parallel>
 ```
+
 #### Arguments
 
 It is also possible to use arguments for subtrees. The syntax of which looks like

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
   <exec_depend>pynput-pip</exec_depend>
   <exec_depend>python3-setuptools</exec_depend>
 
+  <test_depend>action_msgs</test_depend>
   <test_depend>ament_copyright</test_depend>
   <test_depend>python3-pytest</test_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>py_trees_parser</name>
-  <version>0.7.0</version>
+  <version>0.7.1</version>
   <description>A py_trees xml parser</description>
   <maintainer email="e.l.f.foster@tudelft.nl">Erich L Foster</maintainer>
   <license>Apache-2.0</license>

--- a/py_trees_parser/parser.py
+++ b/py_trees_parser/parser.py
@@ -502,7 +502,12 @@ class BTParser:
         elif on_selected is not None:
             self.logger.debug("Found SuccessOnSelected in parameters")
 
-            selection = [child for child in children if child.name in on_selected]
+            selection = [
+                child
+                for child in children
+                if "".join(map(lambda char: char if char.isalnum() else "_", child.name))
+                in on_selected
+            ]
             if len(selection) == 0:
                 raise ValueError("List of children for SuccessOnSelected is empty")
 

--- a/py_trees_parser/parser.py
+++ b/py_trees_parser/parser.py
@@ -502,11 +502,17 @@ class BTParser:
         elif on_selected is not None:
             self.logger.debug("Found SuccessOnSelected in parameters")
 
+            def replace_special(char: str):
+                if char.isalnum():
+                    return char
+
+                self.logger.warning(f"Found special {char} in behavior name, replacing with '_'")
+                return "_"
+
             selection = [
                 child
                 for child in children
-                if "".join(map(lambda char: char if char.isalnum() else "_", child.name))
-                in on_selected
+                if "".join(map(replace_special, child.name)) in on_selected
             ]
             if len(selection) == 0:
                 raise ValueError("List of children for SuccessOnSelected is empty")

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ package_name = "py_trees_parser"
 
 setup(
     name=package_name,
-    version="0.7.0",
+    version="0.7.1",
     packages=find_packages(exclude=["test"]),
     data_files=[
         ("share/ament_index/resource_index/packages", [os.path.join("resource", package_name)]),

--- a/test/data/test_on_selected.xml
+++ b/test/data/test_on_selected.xml
@@ -1,0 +1,13 @@
+<py_trees.composites.Parallel name="Move and Scan"
+  policy="$(py_trees.common.ParallelPolicy.SuccessOnSelected([__mera_va_ue__check_], synchronise=False))">
+  <py_trees.behaviours.SetBlackboardVariable
+    name="Write camera type"
+    variable_name="/perception/camera"
+    variable_value="rgb"
+    overwrite="true"
+  />
+  <py_trees.behaviours.CheckBlackboardVariableValue
+    name="¢@mera va!ue,_check?"
+    check="$(py_trees.common.ComparisonExpression('/perception/camera', value='rgb', operator=operator.is_))"
+  />
+</py_trees.composites.Parallel>

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -224,7 +224,8 @@ def test_SuccessOnSelected_parsing(child_key, synch_key, children, synch):
     assert "policy" not in node.attrib
 
 
-def test_SuccessOnSelected_speacial_chars_in_name(setup_parser):
+def test_SuccessOnSelected_special_chars_in_name(setup_parser):
+    """Test SuccessOnSelected can handle special characters correctly."""
     tree_file = "test_on_selected.xml"
     root = setup_parser(tree_file)
     assert isinstance(root.policy, py_trees.common.ParallelPolicy.SuccessOnSelected)

--- a/test/test_parser.py
+++ b/test/test_parser.py
@@ -224,6 +224,14 @@ def test_SuccessOnSelected_parsing(child_key, synch_key, children, synch):
     assert "policy" not in node.attrib
 
 
+def test_SuccessOnSelected_speacial_chars_in_name(setup_parser):
+    tree_file = "test_on_selected.xml"
+    root = setup_parser(tree_file)
+    assert isinstance(root.policy, py_trees.common.ParallelPolicy.SuccessOnSelected)
+    assert len(root.policy.children) != 0
+    assert root.policy.children[0].name == "¢@mera va!ue,_check?"
+
+
 def test_ParallelPolicy(setup_parser):
     """Test parallel policies are handled correctly."""
     tree_file = "test_parallel_policy.xml"


### PR DESCRIPTION
This PR aims to fix issues where special characters exist in a behavior name that is referenced by `SuccessOnSelected`.

Fixes #18 

## Motivation and Context

The list of children in `SuccessOnSelected` to select is expected to be a list of python variables, thus they cannot have special characters. To deal with this limitation, we replace the special character with an underscore, i.e. `_`.

## Changes

- Handle special characters in `SuccessOnSelected` children.

## Type of changes

- New feature

[comment]: # (Delete the lines in "Type of changes" that are not appropriate)

## Checklist

- [x] Update dependencies
- [x] Update version
- [x] Update README

## Testing

1. `colcon build --packages-up-to py_trees_parser`
2. `colcon test --event-handlers console_cohesion+ --packages-select py_trees_parser`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * SuccessOnSelected policy now correctly recognizes selected children whose names include special or non-ASCII characters.

* **Tests**
  * Added test coverage and sample XML validating special-character node names in SuccessOnSelected and Parallel policies.

* **Chores**
  * Bumped package version to 0.7.1, updated changelog, and added a test-time dependency for the test suite.

* **Documentation**
  * Clarified using underscores to represent special or reserved characters in XML child names.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->